### PR TITLE
fix: 전문가만 조회되도록 수정

### DIFF
--- a/src/main/java/kr/co/hdi/domain/assignment/repository/IndustryDataAssignmentRepositoryImpl.java
+++ b/src/main/java/kr/co/hdi/domain/assignment/repository/IndustryDataAssignmentRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.co.hdi.admin.assignment.dto.query.AssignmentRow;
+import kr.co.hdi.domain.user.entity.Role;
 import kr.co.hdi.domain.year.enums.DomainType;
 import lombok.RequiredArgsConstructor;
 
@@ -55,7 +56,8 @@ public class IndustryDataAssignmentRepositoryImpl implements IndustryDataAssignm
                 )
                 .join(userEntity).on(
                         userYearRound.user.eq(userEntity),
-                        userEntity.deletedAt.isNull()
+                        userEntity.deletedAt.isNull(),
+                        userEntity.role.eq(Role.USER)
                 )
                 .join(industryDataAssignment).on(
                         industryDataAssignment.userYearRound.eq(userYearRound),

--- a/src/main/java/kr/co/hdi/domain/assignment/repository/VisualDataAssignmentRepositoryImpl.java
+++ b/src/main/java/kr/co/hdi/domain/assignment/repository/VisualDataAssignmentRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.co.hdi.admin.assignment.dto.query.AssignmentRow;
+import kr.co.hdi.domain.user.entity.Role;
 import kr.co.hdi.domain.year.enums.DomainType;
 import lombok.RequiredArgsConstructor;
 
@@ -54,7 +55,8 @@ public class VisualDataAssignmentRepositoryImpl implements  VisualDataAssignment
                 )
                 .join(userEntity).on(
                         userYearRound.user.eq(userEntity),
-                        userEntity.deletedAt.isNull()
+                        userEntity.deletedAt.isNull(),
+                        userEntity.role.eq(Role.USER)
                 )
                 .join(visualDataAssignment).on(
                         visualDataAssignment.userYearRound.eq(userYearRound),


### PR DESCRIPTION
## #⃣ 연관된 이슈

> ex)

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (스크린샷 첨부)

- 전문가 데이터셋 할당 페이지에서 ADMIN 유저도 조회되는 문제가 있어, 조회 로직에 USER로 필터링 조건을 추가했습니다
- (전문가-데이터 할당 페이지와 엑셀 다운로드 모두에 적용되는 조회 로직입니다)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요