### PR TITLE
fix: 이미지 original 이름 있을 때만 조회 url 반환하도록 수정

### DIFF
--- a/src/main/java/kr/co/hdi/admin/data/service/IndustryDataService.java
+++ b/src/main/java/kr/co/hdi/admin/data/service/IndustryDataService.java
@@ -7,6 +7,7 @@ import kr.co.hdi.admin.data.exception.DataException;
 import kr.co.hdi.domain.data.entity.IndustryData;
 import kr.co.hdi.domain.data.entity.VisualData;
 import kr.co.hdi.domain.data.enums.IndustryDataCategory;
+import kr.co.hdi.domain.data.enums.IndustryImageType;
 import kr.co.hdi.domain.data.enums.VisualDataCategory;
 import kr.co.hdi.domain.data.repository.IndustryDataRepository;
 import kr.co.hdi.domain.year.entity.Year;
@@ -71,9 +72,9 @@ public class IndustryDataService {
                         entry.getValue().stream()
                                 .map(i -> IndustryDataResponse.from(
                                         i,
-                                        imageService.getImageUrl(i.getDetailImagePath()),
-                                        imageService.getImageUrl(i.getFrontImagePath()),
-                                        imageService.getImageUrl(i.getSideImagePath())
+                                        resolveIndustryImageUrl(i, IndustryImageType.DETAIL),
+                                        resolveIndustryImageUrl(i, IndustryImageType.FRONT),
+                                        resolveIndustryImageUrl(i, IndustryImageType.SIDE)
                                 ))
                                 .toList()
                 ))
@@ -90,10 +91,29 @@ public class IndustryDataService {
 
         return IndustryDataResponse.from(
                 industryData,
-                imageService.getImageUrl(industryData.getDetailImagePath()),
-                imageService.getImageUrl(industryData.getFrontImagePath()),
-                imageService.getImageUrl(industryData.getSideImagePath())
+                resolveIndustryImageUrl(industryData, IndustryImageType.DETAIL),
+                resolveIndustryImageUrl(industryData, IndustryImageType.FRONT),
+                resolveIndustryImageUrl(industryData, IndustryImageType.SIDE)
         );
+    }
+
+    private String resolveIndustryImageUrl(
+            IndustryData data,
+            IndustryImageType type
+    ) {
+        return switch (type) {
+            case DETAIL -> data.getOriginalDetailImagePath() == null
+                    ? null
+                    : imageService.getImageUrl(data.getDetailImagePath());
+
+            case FRONT -> data.getOriginalFrontImagePath() == null
+                    ? null
+                    : imageService.getImageUrl(data.getFrontImagePath());
+
+            case SIDE -> data.getOriginalSideImagePath() == null
+                    ? null
+                    : imageService.getImageUrl(data.getSideImagePath());
+        };
     }
 
     /*

--- a/src/main/java/kr/co/hdi/admin/data/service/VisualDataService.java
+++ b/src/main/java/kr/co/hdi/admin/data/service/VisualDataService.java
@@ -71,7 +71,7 @@ public class VisualDataService {
                         entry.getValue().stream()
                                 .map(v -> VisualDataResponse.from(
                                     v,
-                                    imageService.getImageUrl(v.getLogoImage())
+                                    resolveImageUrl(v)
                                 ))
                                 .toList()
                 ))
@@ -86,8 +86,15 @@ public class VisualDataService {
         VisualData visualData = visualDataRepository.findById(datasetId)
                 .orElseThrow(() -> new DataException(DataErrorCode.DATA_NOT_FOUND));
 
-        String imageUrl = imageService.getImageUrl(visualData.getLogoImage());
+        String imageUrl = resolveImageUrl(visualData);
         return VisualDataResponse.from(visualData, imageUrl);
+    }
+
+    private String resolveImageUrl(VisualData visualData) {
+        if (visualData.getOriginalLogoImage() == null) {
+            return null;
+        }
+        return imageService.getImageUrl(visualData.getLogoImage());
     }
 
     /*

--- a/src/main/java/kr/co/hdi/domain/data/enums/IndustryImageType.java
+++ b/src/main/java/kr/co/hdi/domain/data/enums/IndustryImageType.java
@@ -1,0 +1,7 @@
+package kr.co.hdi.domain.data.enums;
+
+public enum IndustryImageType {
+    DETAIL,
+    FRONT,
+    SIDE
+}


### PR DESCRIPTION
## #⃣ 연관된 이슈

> ex) #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (스크린샷 첨부)

- original 필드를 확인해서 null이면 null반환, null이 아니면 S3 주소 반환하도록 수정했습니다

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요