### PR TITLE
fix: 세션을 인메모리 대신 Redis에 저장하도록 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'org.postgresql:postgresql'
 
-//    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
 
     // querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,16 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
       ssl:
-        enabled: true
+        # docker-compose.yml의 redis 컨테이너(redis:alpine)는 TLS 없이 뜬다.
+        # 운영 배포(be_deploy.yml)도 이 docker-compose로 나가므로 기본값은 false.
+        # TLS 종료가 되는 redis(ElastiCache 등)로 옮기면 REDIS_SSL_ENABLED=true로 설정.
+        enabled: ${REDIS_SSL_ENABLED:false}
+
+  session:
+    store-type: redis
+    timeout: 2h
+    redis:
+      namespace: hdi:session
 
   servlet:
     session:


### PR DESCRIPTION
## PR 작성 전 체크 리스트 (PR 생성시 해당 항목은 삭제 후 올려주세요!)

## ✨ PR 제목 규칙
> `feat: (docs: / hotfix: / fix: ) 기능명 (#이슈번호)` 형식으로 작성  
> 예시: `feat: google OAuth 구현 (#14)`

`close #{이슈 번호}`을 사용하면 PR이 merge되면 해당 이슈가 자동으로 닫힙니다.

## #⃣ 연관된 이슈

> ex) #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (스크린샷 첨부)

- Redis 스타터 의존성 활성화 + spring-session-data-redis 추가
- spring.session.store-type: redis 설정 추가
- spring.data.redis.ssl.enabled를 REDIS_SSL_ENABLED 환경변수로 분리 (기본값 false)
  - 운영 배포(docker-compose)의 redis는 TLS 없이 뜨는데 기존 설정은 true였음
  - 지금까지 redis 의존성 자체가 비활성화돼있어서 한 번도 검증된 적 없던 설정이었음
배경: 세션이 Tomcat 인메모리 방식이라, main 브랜치 push 시 자동배포(docker-compose up -d)
때마다 로그인 중인 평가자 전원이 강제 로그아웃되고 있었음. Redis로 옮겨서 재배포/재시작에도
세션이 유지되도록 함.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요