### PR TITLE
fix: 설문 응답 동시 저장 시 중복 row 생성되는 race condition 수정

### DIFF
--- a/docs/troubleshooting/visual-response-duplicate-race-condition.md
+++ b/docs/troubleshooting/visual-response-duplicate-race-condition.md
@@ -1,0 +1,276 @@
+# 설문 응답 동시 저장 시 중복 row가 생길 수 있는 Race Condition 수정
+
+## 배경
+
+기존에는 정성평가(서술형 응답)를 글자 하나 입력할 때마다 즉시 저장하는 실시간 저장 방식이었고,
+이 시기에 "가끔 정성평가가 저장이 안 된다"는 문의가 간간이 있었다. 이후 실시간 저장 방식을
+버리고, 사용자가 "제출" 버튼을 눌러야 한 번에 전체 응답을 저장하는 방식(`save-all` /
+`submit-all`)으로 구조를 바꿨다.
+
+구조를 바꾼 뒤 코드 전체를 다시 훑어보다가, 응답 저장 로직 자체에 동시 요청에 취약한
+race condition이 남아있는 걸 발견해서 정리한다.
+
+## 문제 코드
+
+`SurveyService.saveVisualSurveyResponse` (산업 디자인 쪽도 동일한 구조):
+
+```java
+// 응답 조회 (없으면 생성)
+VisualResponse visualResponse = visualResponseRepository
+        .findByUserYearRoundIdAndVisualSurveyIdAndVisualDataId(
+                userYearRound.getId(),
+                request.surveyId(),
+                dataId
+        )
+        .orElseGet(() -> {
+            assignment.incrementResponseCount();
+
+            return VisualResponse.builder()
+                    .userYearRound(userYearRound)
+                    .visualSurvey(visualSurveyRepository.getReferenceById(request.surveyId()))
+                    .visualData(visualDataRepository.getReferenceById(dataId))
+                    .build();
+        });
+```
+
+전형적인 **check-then-act** 패턴이다. "이 문항에 대한 응답이 있는지 조회 → 없으면 새로
+만든다"는 흐름인데, 이 조회와 생성 사이에 원자성이 없다. 그리고 결정적으로,
+`VisualResponse`/`IndustryResponse` 엔티티에는 `(userYearRound, survey, data)` 조합에 대한
+**DB 유니크 제약이 걸려있지 않았다.**
+
+즉 아래와 같은 상황이 가능하다:
+
+1. 더블클릭, 네트워크 재시도, 같은 설문을 두 탭에서 열어놓고 저장 등으로 같은 문항에 대한
+   저장 요청이 거의 동시에 두 번 들어온다.
+2. 두 요청이 모두 `findByUserYearRoundIdAndVisualSurveyIdAndVisualDataId(...)`로 조회했을 때
+   서로의 커밋을 아직 보지 못한 채 "없음"을 리턴받는다.
+3. 둘 다 `orElseGet`으로 진입해서 각각 새 `VisualResponse` row를 INSERT한다.
+4. 같은 문항에 대해 row가 2개 생긴다.
+
+응답 조회 시엔 `Map`에 마지막 것만 덮어써져서 겉으론 멀쩡해 보이지만, 실제로는 오래된
+(또는 비어있는) 응답 row가 남아 있다가 어떤 시점엔 그게 조회되면서 "분명 입력했는데
+사라졌다"는 식으로 나타날 수 있다.
+
+## 해결 방법
+
+### 1) DB 유니크 제약 추가
+
+```java
+@Entity
+@Table(
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_visualResponse_userYearRound_survey_data",
+                columnNames = {
+                        "user_year_round_user_year_round_id",
+                        "visual_survey_visual_survey_id",
+                        "visual_data_visual_data_id"
+                }
+        )
+)
+public class VisualResponse extends BaseTimeEntityWithDeletion { ... }
+```
+
+`IndustryResponse`에도 동일하게 `(userYearRound, industrySurvey, industryData)` 조합으로
+유니크 제약을 추가했다.
+
+### 2) 생성을 별도 트랜잭션(REQUIRES_NEW)으로 분리
+
+PostgreSQL은 트랜잭션 안에서 제약 위반 등 SQL 에러가 한 번 나면, 그 트랜잭션 전체가
+abort 상태가 되어 이후 어떤 쿼리도 거부한다 (`current transaction is aborted, commands
+ignored until end of transaction block`). 그래서 실패할 수도 있는 INSERT 시도를
+`REQUIRES_NEW`로 분리된 트랜잭션에서 실행해야, 경쟁에서 진 요청이 "그 INSERT 트랜잭션만"
+롤백하고 원래 트랜잭션은 계속 이어갈 수 있다.
+
+```java
+@Component
+@RequiredArgsConstructor
+public class SurveyResponseUpsertHelper {
+
+    private final VisualResponseRepository visualResponseRepository;
+    private final VisualSurveyRepository visualSurveyRepository;
+    private final VisualDataRepository visualDataRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public VisualResponse createVisualResponse(UserYearRound userYearRound, Long surveyId, Long dataId) {
+        return visualResponseRepository.saveAndFlush(
+                VisualResponse.builder()
+                        .userYearRound(userYearRound)
+                        .visualSurvey(visualSurveyRepository.getReferenceById(surveyId))
+                        .visualData(visualDataRepository.getReferenceById(dataId))
+                        .build()
+        );
+    }
+}
+```
+
+호출부에서는 유니크 제약 위반(`DataIntegrityViolationException`)을 잡아서, 경쟁에서
+이긴 요청이 만든 row를 재조회해서 쓴다.
+
+```java
+private VisualResponse createVisualResponseSafely(
+        UserYearRound userYearRound, VisualDataAssignment assignment, Long dataId, Long surveyId
+) {
+    try {
+        VisualResponse created = surveyResponseUpsertHelper.createVisualResponse(userYearRound, surveyId, dataId);
+        assignment.incrementResponseCount(); // 실제로 새로 만든 경우에만 카운트
+        return created;
+    } catch (DataIntegrityViolationException e) {
+        log.info("동시 요청으로 인한 VisualResponse 중복 생성 시도 감지 - 재조회로 처리");
+        return visualResponseRepository
+                .findByUserYearRoundIdAndVisualSurveyIdAndVisualDataId(userYearRound.getId(), surveyId, dataId)
+                .orElseThrow(() -> new SurveyException(SurveyErrorCode.NOT_FOUND_DATA_ASSIGNMENT));
+    }
+}
+```
+
+## 여기서 삽질한 부분: catch 위치가 잘못되면 더 큰 사고가 난다
+
+처음엔 `try-catch`를 `REQUIRES_NEW` 메서드 **몸통 안**에 넣었었다.
+
+```java
+// (첫 번째 시도 - 문제가 있던 버전)
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+public VisualResponse tryCreateVisualResponse(...) {
+    try {
+        return visualResponseRepository.saveAndFlush(...);
+    } catch (DataIntegrityViolationException e) {
+        return null; // 여기서 잡고 정상 반환
+    }
+}
+```
+
+동시 요청 4개로 재현 테스트를 돌려봤더니, 유니크 제약 자체는 잘 작동해서 row는 정확히
+1개로 유지됐다. 그런데:
+
+```
+요청 4개 중 성공 1 / 실패 3
+생성된 visual_response row 개수: 1
+```
+
+4개 중 **3개가 `Transaction silently rolled back because it has been marked as
+rollback-only` 예외로 실패**했다. 데이터 중복은 안 생겼지만, 경쟁에서 진 요청들이
+정상적으로 fallback(재조회 후 업데이트)하지 못하고 그냥 500 에러로 죽어버린 것이다.
+
+**원인:** `saveAndFlush()`가 던진 예외를 메서드 안에서 잡고 `null`을 정상 반환하면,
+Spring의 트랜잭션 인터셉터 입장에서는 "예외 없이 정상 종료됐네" 하고 커밋을 시도한다.
+그런데 Hibernate는 flush 실패 시점에 이미 그 영속성 컨텍스트(세션)를 "rollback-only"로
+내부적으로 마킹해둔 상태라, 커밋 시도 자체가 실패하면서 `UnexpectedRollbackException`이
+새로 던져진다. 이 예외는 메서드 몸통 안의 catch로는 잡을 수 없다 — 발생 시점이
+"메서드가 리턴한 이후, 프록시가 커밋을 시도하는 순간"이기 때문이다. 그 결과 이 예외가
+그대로 호출부(`SurveyService`)까지 전파되고, 호출부의 바깥 트랜잭션까지 롤백 대상으로
+마킹되어 정상적인 재조회/업데이트까지 전부 실패해버렸다.
+
+**해결:** catch를 `REQUIRES_NEW` 메서드 몸통이 아니라, **그 메서드를 호출하는 쪽에서
+호출 자체를 감싸도록** 옮겼다. 이러면 Spring의 가장 표준적인 경로를 타게 된다 — 예외
+발생 → `TransactionInterceptor`가 예외를 감지 → REQUIRES_NEW 트랜잭션을 정상적으로
+롤백 → 원본 예외를 그대로 재던짐(rethrow) → 호출부는 (한 번도 오염되지 않은) 자신의
+트랜잭션 안에서 그 예외를 캐치해서 재조회로 넘어간다.
+
+```java
+// SurveyResponseUpsertHelper - 예외를 그냥 던지게 둔다
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+public VisualResponse createVisualResponse(UserYearRound userYearRound, Long surveyId, Long dataId) {
+    return visualResponseRepository.saveAndFlush(...);
+}
+
+// SurveyService - 호출 자체를 try-catch로 감싼다
+try {
+    VisualResponse created = surveyResponseUpsertHelper.createVisualResponse(userYearRound, surveyId, dataId);
+    ...
+} catch (DataIntegrityViolationException e) {
+    // 재조회
+}
+```
+
+## 검증
+
+같은 문항에 동시 요청 4개를 쏴서 결과 row 개수를 확인하는 재현용 러너
+(`DuplicateResponseReproRunner`, profile: `repro-duplicate-response`)를 만들어서 검증했다.
+
+```java
+for (int i = 0; i < CONCURRENT_REQUESTS; i++) {
+    int score = (i % 5) + 1;
+    executor.submit(() -> {
+        try {
+            startGate.await();
+            surveyService.saveVisualSurveyResponse(
+                    DATA_ID, USER_ID,
+                    new SurveyResponseRequest(SURVEY_ID, score, null)
+            );
+            successCount.incrementAndGet();
+        } catch (Exception e) {
+            failureCount.incrementAndGet();
+        } finally {
+            doneGate.countDown();
+        }
+    });
+}
+```
+
+수정 후 실행 결과:
+
+```
+▶ 4개 동시 요청 발사 (userId=105, dataId=2088, surveyId=70)
+동시 요청으로 인한 VisualResponse 중복 생성 시도 감지 (userYearRoundId=169, surveyId=70, dataId=2088) - 재조회로 처리
+동시 요청으로 인한 VisualResponse 중복 생성 시도 감지 (userYearRoundId=169, surveyId=70, dataId=2088) - 재조회로 처리
+동시 요청으로 인한 VisualResponse 중복 생성 시도 감지 (userYearRoundId=169, surveyId=70, dataId=2088) - 재조회로 처리
+========================================
+요청 4개 중 성공 4 / 실패 0
+생성된 visual_response row 개수: 1
+✅ 중복 없음 (fix 적용됨)
+```
+
+4개 모두 성공했고, 그중 3개는 경쟁에서 져서 재조회 경로를 탔지만 에러 없이 정상적으로
+값을 업데이트했다. DB에 직접 쿼리해서도 확인:
+
+```sql
+SELECT visual_response_id, user_year_round_user_year_round_id AS user_year_round_id,
+       visual_data_visual_data_id AS visual_data_id,
+       visual_survey_visual_survey_id AS visual_survey_id,
+       number_response, created_at, updated_at
+FROM visual_response
+WHERE user_year_round_user_year_round_id = 169
+  AND visual_data_visual_data_id = 2088
+  AND visual_survey_visual_survey_id = 70;
+```
+
+```
+ visual_response_id | user_year_round_id | visual_data_id | visual_survey_id | number_response |         created_at         |         updated_at
+--------------------+--------------------+-----------------+-------------------+------------------+----------------------------+----------------------------
+             141502 |                169 |            2088 |               70 |               3 | 2026-08-09 03:04:32.128918 | 2026-08-09 03:04:32.207843
+(1 row)
+```
+
+동시 요청 4개가 들어와도 row는 정확히 1개만 남는다.
+
+## 배포 시 주의할 점
+
+- 이 프로젝트는 Flyway/Liquibase 없이 `spring.jpa.hibernate.ddl-auto: update`를 쓰고
+  있어서, 유니크 제약이 배포 시 자동으로 `ALTER TABLE`로 적용된다. **기존 데이터에
+  이미 중복 row가 있으면 이 ALTER TABLE 자체가 실패**할 수 있으므로, 배포 전
+  아래 쿼리로 기존 중복 여부를 먼저 확인해야 한다.
+
+```sql
+SELECT user_year_round_user_year_round_id, visual_survey_visual_survey_id, visual_data_visual_data_id, COUNT(*)
+FROM visual_response
+GROUP BY 1, 2, 3
+HAVING COUNT(*) > 1;
+```
+
+- `REQUIRES_NEW`는 요청 하나당 최악의 경우 커넥션을 2개(바깥 트랜잭션 + REQUIRES_NEW
+  트랜잭션)까지 동시에 사용할 수 있다. HikariCP 기본 풀 크기(10)를 기준으로, 재현
+  테스트에서 동시 요청 수를 너무 크게 잡으면(예: 10개) 커넥션 풀이 고갈되어 무관한
+  요청까지 타임아웃날 수 있다 (`Connection is not available, request timed out`).
+  실제 운영 트래픽에서는 완전히 동일한 문항에 여러 명이 정확히 같은 순간 몰릴 확률이
+  낮고, REQUIRES_NEW 구간 자체도 짧아서 문제될 가능성은 낮지만, 이 패턴을 다른
+  곳에도 넓게 쓰게 된다면 풀 크기를 같이 고려해야 한다.
+
+## 요약
+
+| 항목 | 내용 |
+|---|---|
+| 증상 | 동시 저장 요청 시 같은 문항에 응답 row가 중복 생성될 수 있음 (check-then-act race) |
+| 원인 | `VisualResponse`/`IndustryResponse`에 유니크 제약이 없는 상태로 "조회 후 없으면 생성" 패턴을 사용 |
+| 1차 해결 시도의 함정 | REQUIRES_NEW 메서드 내부에서 예외를 캐치하면, 지연된 커밋 실패(`UnexpectedRollbackException`)가 캐치를 우회해 바깥 트랜잭션까지 롤백시킴 |
+| 최종 해결 | DB 유니크 제약 + REQUIRES_NEW 트랜잭션으로 생성 시도, 예외 캐치는 반드시 호출부에서 |
+| 검증 | 동시 요청 4개 재현 테스트 → 성공 4/4, row 1개로 수렴 확인 (DB 직접 조회로 재확인) |

--- a/src/main/java/kr/co/hdi/admin/repro/runner/DuplicateResponseReproRunner.java
+++ b/src/main/java/kr/co/hdi/admin/repro/runner/DuplicateResponseReproRunner.java
@@ -1,0 +1,126 @@
+package kr.co.hdi.admin.repro.runner;
+
+import kr.co.hdi.domain.response.entity.VisualResponse;
+import kr.co.hdi.domain.response.repository.VisualResponseRepository;
+import kr.co.hdi.survey.dto.request.SurveyResponseRequest;
+import kr.co.hdi.survey.service.SurveyService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * [재현/검증 전용] 같은 설문 문항에 대해 동시에 여러 번 저장 요청을 보냈을 때
+ * VisualResponse row가 중복 생성되는지 확인하는 러너.
+ * (fix/duplicate-survey-response 브랜치 작업 검증용 - 병합 전 삭제해도 무방)
+ *
+ * 사용법
+ *  1) 아래 USER_ID / DATA_ID / SURVEY_ID를 실제 DB 값으로 채운다.
+ *     - USER_ID   : 현재 평가 회차에 참여 중인 평가자의 user.id
+ *     - DATA_ID   : 그 평가자에게 배정된 visual_data.id
+ *     - SURVEY_ID : 현재 연도 NUMBER 타입 visual_survey.id
+ *  2) 아래 명령으로 실행 (반드시 테스트용 DB/데이터로만!)
+ *       ./gradlew bootRun --args='--spring.profiles.active=repro-duplicate-response'
+ *  3) 콘솔 마지막에 찍히는 "생성된 row 개수"를 확인
+ *       - fix 적용 전 코드에서 돌리면: 1보다 큰 수가 나올 수 있음 (race 재현)
+ *       - fix 적용 후 코드에서 돌리면: 항상 1
+ *
+ * 실행할 때마다 해당 (user, data, survey) 조합의 기존 응답을 먼저 지우고 시작한다.
+ */
+@Slf4j
+@Component
+@Profile("repro-duplicate-response")
+@RequiredArgsConstructor
+public class DuplicateResponseReproRunner implements CommandLineRunner {
+
+    private static final Long USER_ID = 105L;   // TODO: 실제 user.id로 교체
+    private static final Long DATA_ID = 2088L;   // TODO: 실제 visual_data.id로 교체
+    private static final Long SURVEY_ID = 70L; // TODO: 실제 visual_survey.id로 교체
+
+    // 주의: tryCreateVisualResponse는 REQUIRES_NEW라서 요청 1개가 최악의 경우
+    // 커넥션을 2개(바깥 트랜잭션 + REQUIRES_NEW 트랜잭션)까지 동시에 물 수 있다.
+    // HikariCP 기본 풀 크기(10)에 여유를 두고 잡는다 (2 * N < pool size).
+    private static final int CONCURRENT_REQUESTS = 4;
+
+    private final SurveyService surveyService;
+    private final VisualResponseRepository visualResponseRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        if (USER_ID == 0L || DATA_ID == 0L || SURVEY_ID == 0L) {
+            log.error("USER_ID / DATA_ID / SURVEY_ID를 실제 DB 값으로 채운 뒤 다시 실행하세요.");
+            return;
+        }
+
+        deleteExistingResponses();
+
+        ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_REQUESTS);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch doneGate = new CountDownLatch(CONCURRENT_REQUESTS);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        for (int i = 0; i < CONCURRENT_REQUESTS; i++) {
+            int score = (i % 5) + 1; // 1~5 아무 점수
+            executor.submit(() -> {
+                try {
+                    startGate.await();
+                    surveyService.saveVisualSurveyResponse(
+                            DATA_ID, USER_ID,
+                            new SurveyResponseRequest(SURVEY_ID, score, null)
+                    );
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                    log.warn("요청 실패: {}", e.getMessage());
+                } finally {
+                    doneGate.countDown();
+                }
+            });
+        }
+
+        log.info("▶ {}개 동시 요청 발사 (userId={}, dataId={}, surveyId={})",
+                CONCURRENT_REQUESTS, USER_ID, DATA_ID, SURVEY_ID);
+        startGate.countDown(); // 전부 동시에 출발
+        doneGate.await(30, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        long rowCount = matchingResponses().size();
+
+        log.info("========================================");
+        log.info("요청 {}개 중 성공 {} / 실패 {}", CONCURRENT_REQUESTS, successCount.get(), failureCount.get());
+        log.info("생성된 visual_response row 개수: {}", rowCount);
+        if (successCount.get() == 0) {
+            log.warn("⚠️ 성공한 요청이 0개입니다 - 이 결과는 유효한 테스트가 아닙니다 " +
+                    "(커넥션 풀 고갈 등 다른 원인일 가능성이 높음). 위 '요청 실패' 로그를 확인하세요.");
+        } else if (rowCount > 1) {
+            log.info("❌ 중복 발생 (fix 적용 전 코드)");
+        } else {
+            log.info("✅ 중복 없음 (fix 적용됨)");
+        }
+        log.info("========================================");
+    }
+
+    private void deleteExistingResponses() {
+        List<VisualResponse> existing = matchingResponses();
+        if (!existing.isEmpty()) {
+            visualResponseRepository.deleteAll(existing);
+            log.info("기존 응답 {}건 정리 후 재현 시작", existing.size());
+        }
+    }
+
+    private List<VisualResponse> matchingResponses() {
+        return visualResponseRepository.findAllByVisualDataIdAndUserId(DATA_ID, USER_ID).stream()
+                .filter(r -> r.getVisualSurvey().getId().equals(SURVEY_ID))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/kr/co/hdi/domain/response/entity/IndustryResponse.java
+++ b/src/main/java/kr/co/hdi/domain/response/entity/IndustryResponse.java
@@ -15,6 +15,16 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@Table(
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_industryResponse_userYearRound_survey_data",
+                columnNames = {
+                        "user_year_round_user_year_round_id",
+                        "industry_survey_industry_survey_id",
+                        "industry_data_industry_data_id"
+                }
+        )
+)
 public class IndustryResponse extends BaseTimeEntityWithDeletion {
 
     @Id

--- a/src/main/java/kr/co/hdi/domain/response/entity/VisualResponse.java
+++ b/src/main/java/kr/co/hdi/domain/response/entity/VisualResponse.java
@@ -15,6 +15,16 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@Table(
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_visualResponse_userYearRound_survey_data",
+                columnNames = {
+                        "user_year_round_user_year_round_id",
+                        "visual_survey_visual_survey_id",
+                        "visual_data_visual_data_id"
+                }
+        )
+)
 public class VisualResponse extends BaseTimeEntityWithDeletion {
 
     @Id

--- a/src/main/java/kr/co/hdi/survey/service/SurveyResponseUpsertHelper.java
+++ b/src/main/java/kr/co/hdi/survey/service/SurveyResponseUpsertHelper.java
@@ -1,0 +1,84 @@
+package kr.co.hdi.survey.service;
+
+import kr.co.hdi.domain.data.repository.IndustryDataRepository;
+import kr.co.hdi.domain.data.repository.VisualDataRepository;
+import kr.co.hdi.domain.response.entity.IndustryResponse;
+import kr.co.hdi.domain.response.entity.VisualResponse;
+import kr.co.hdi.domain.response.repository.IndustryResponseRepository;
+import kr.co.hdi.domain.response.repository.VisualResponseRepository;
+import kr.co.hdi.domain.survey.repository.IndustrySurveyRepository;
+import kr.co.hdi.domain.survey.repository.VisualSurveyRepository;
+import kr.co.hdi.domain.year.entity.UserYearRound;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 설문 응답(VisualResponse/IndustryResponse) row 생성 시 동시 요청으로 인한
+ * 중복 row 생성을 막기 위한 헬퍼.
+ *
+ * "조회 후 없으면 생성" 흐름은 동시에 두 요청이 들어오면 둘 다 "없음"을 보고
+ * 각각 insert를 시도할 수 있다 (check-then-act race). 이를 막기 위해
+ * VisualResponse/IndustryResponse 에 (userYearRound, survey, data) 조합의
+ * DB 유니크 제약을 걸어두고, 이 클래스에서 생성을 별도 트랜잭션(REQUIRES_NEW)으로
+ * 시도한다.
+ *
+ * REQUIRES_NEW를 쓰는 이유: PostgreSQL은 트랜잭션 내에서 한 번 제약 위반 에러가
+ * 나면 그 트랜잭션 전체가 abort 상태가 되어 이후 쿼리를 거부한다. 생성 시도를
+ * 별도 트랜잭션으로 분리해두면, 경쟁에서 진 쪽은 이 트랜잭션만 롤백되고
+ * 호출부(SurveyService)의 원래 트랜잭션은 영향을 받지 않아 이어서 재조회할 수 있다.
+ *
+ * 주의: 실패 시의 catch는 반드시 "이 메서드를 호출하는 쪽"에서 해야 한다
+ * (SurveyService의 createXxxResponseSafely 참고). 이 메서드 내부에서 예외를
+ * 잡고 정상 반환해버리면, 메서드 몸통은 정상 종료됐다고 판단한 Spring 트랜잭션
+ * 인터셉터가 커밋을 시도하다가 (Hibernate가 flush 실패로 세션을 이미 rollback-only로
+ * 마킹해놔서) UnexpectedRollbackException을 던지게 되고, 이게 그대로 바깥
+ * 트랜잭션까지 뚫고 올라가 정상적인 요청까지 실패시킨다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SurveyResponseUpsertHelper {
+
+    private final VisualResponseRepository visualResponseRepository;
+    private final VisualSurveyRepository visualSurveyRepository;
+    private final VisualDataRepository visualDataRepository;
+
+    private final IndustryResponseRepository industryResponseRepository;
+    private final IndustrySurveyRepository industrySurveyRepository;
+    private final IndustryDataRepository industryDataRepository;
+
+    /**
+     * 새 VisualResponse 생성을 시도한다.
+     * 동시 요청이 먼저 만들어 유니크 제약에 걸리면 DataIntegrityViolationException을
+     * 그대로 던진다 (호출부에서 잡아서 재조회하도록).
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public VisualResponse createVisualResponse(UserYearRound userYearRound, Long surveyId, Long dataId) {
+        return visualResponseRepository.saveAndFlush(
+                VisualResponse.builder()
+                        .userYearRound(userYearRound)
+                        .visualSurvey(visualSurveyRepository.getReferenceById(surveyId))
+                        .visualData(visualDataRepository.getReferenceById(dataId))
+                        .build()
+        );
+    }
+
+    /**
+     * 새 IndustryResponse 생성을 시도한다.
+     * 동시 요청이 먼저 만들어 유니크 제약에 걸리면 DataIntegrityViolationException을
+     * 그대로 던진다 (호출부에서 잡아서 재조회하도록).
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public IndustryResponse createIndustryResponse(UserYearRound userYearRound, Long surveyId, Long dataId) {
+        return industryResponseRepository.saveAndFlush(
+                IndustryResponse.builder()
+                        .userYearRound(userYearRound)
+                        .industrySurvey(industrySurveyRepository.getReferenceById(surveyId))
+                        .industryData(industryDataRepository.getReferenceById(dataId))
+                        .build()
+        );
+    }
+}

--- a/src/main/java/kr/co/hdi/survey/service/SurveyService.java
+++ b/src/main/java/kr/co/hdi/survey/service/SurveyService.java
@@ -47,6 +47,7 @@ import kr.co.hdi.survey.exception.SurveyException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContextException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -83,6 +84,7 @@ public class SurveyService {
     private final ImageService imageService;
     private final VisualDataService visualDataService;
     private final IndustryDataService industryDataService;
+    private final SurveyResponseUpsertHelper surveyResponseUpsertHelper;
 
     /*
     [공통] 현재 평가 정보 조회
@@ -288,25 +290,21 @@ public class SurveyService {
         VisualDataAssignment assignment = visualDataAssignmentRepository.findByUserYearRoundIdAndVisualDataId(userYearRound.getId(), dataId)
                 .orElseThrow(() -> new SurveyException(SurveyErrorCode.NOT_FOUND_DATA_ASSIGNMENT));
 
-        // 응답 조회 (없으면 생성)
+        // 설문 문항은 현재 트랜잭션에서 직접 조회 (아래 생성 분기가 별도 트랜잭션을 타므로,
+        // 거기서 얻은 프록시를 나중에 여기서 초기화하려 하면 LazyInitializationException이 날 수 있음)
+        VisualSurvey survey = visualSurveyRepository.findById(request.surveyId())
+                .orElseThrow(() -> new SurveyException(SurveyErrorCode.SURVEY_NOT_FOUND));
+
+        // 응답 조회 (없으면 생성 - 동시 요청으로 중복 row가 생기지 않도록 안전하게 생성)
         VisualResponse visualResponse = visualResponseRepository
                 .findByUserYearRoundIdAndVisualSurveyIdAndVisualDataId(
                         userYearRound.getId(),
                         request.surveyId(),
                         dataId
                 )
-                .orElseGet(() -> {
-                    assignment.incrementResponseCount();
-
-                    return VisualResponse.builder()
-                            .userYearRound(userYearRound)
-                            .visualSurvey(visualSurveyRepository.getReferenceById(request.surveyId()))
-                            .visualData(visualDataRepository.getReferenceById(dataId))
-                            .build();
-                });
+                .orElseGet(() -> createVisualResponseSafely(userYearRound, assignment, dataId, request.surveyId()));
 
         // 응답값 갱신
-        VisualSurvey survey = visualResponse.getVisualSurvey();
         if (survey.getSurveyType() == SurveyType.NUMBER) {
             visualResponse.updateNumberResponse(request.response());
         } else if (survey.getSurveyType() == SurveyType.TEXT) {
@@ -316,6 +314,33 @@ public class SurveyService {
             visualResponse.updateTextResponse(request.textResponse());
         }
         visualResponseRepository.save(visualResponse);
+    }
+
+    /*
+    VisualResponse 생성 (동시 요청 대비)
+    - 먼저 별도 트랜잭션(REQUIRES_NEW)으로 생성을 시도한다.
+    - 동시에 다른 요청이 먼저 만들어서 유니크 제약(uk_visualResponse_userYearRound_survey_data)에
+      걸리면 DataIntegrityViolationException이 던져지는데, 이땐 그 요청이 만든 row를
+      재조회해서 사용한다.
+    - catch는 반드시 여기(호출부)에서 해야 한다. surveyResponseUpsertHelper 메서드
+      내부에서 잡으면 REQUIRES_NEW 트랜잭션의 지연된 커밋 실패(UnexpectedRollbackException)가
+      이 메서드의 바깥 트랜잭션까지 전파되어 정상 요청까지 롤백시킨다.
+    */
+    private VisualResponse createVisualResponseSafely(
+            UserYearRound userYearRound, VisualDataAssignment assignment, Long dataId, Long surveyId
+    ) {
+        try {
+            VisualResponse created = surveyResponseUpsertHelper.createVisualResponse(userYearRound, surveyId, dataId);
+            // 이 요청이 실제로 새로 만든 경우에만 카운트 (경쟁에서 진 요청은 중복 카운트하지 않음)
+            assignment.incrementResponseCount();
+            return created;
+        } catch (DataIntegrityViolationException e) {
+            log.info("동시 요청으로 인한 VisualResponse 중복 생성 시도 감지 (userYearRoundId={}, surveyId={}, dataId={}) - 재조회로 처리",
+                    userYearRound.getId(), surveyId, dataId);
+            return visualResponseRepository
+                    .findByUserYearRoundIdAndVisualSurveyIdAndVisualDataId(userYearRound.getId(), surveyId, dataId)
+                    .orElseThrow(() -> new SurveyException(SurveyErrorCode.NOT_FOUND_DATA_ASSIGNMENT));
+        }
     }
 
     /*
@@ -359,25 +384,21 @@ public class SurveyService {
         IndustryDataAssignment assignment = industryDataAssignmentRepository.findByUserYearRoundIdAndIndustryDataId(userYearRound.getId(), dataId)
                 .orElseThrow(() -> new SurveyException(SurveyErrorCode.NOT_FOUND_DATA_ASSIGNMENT));
 
-        // 응답 조회 (없으면 생성)
+        // 설문 문항은 현재 트랜잭션에서 직접 조회 (아래 생성 분기가 별도 트랜잭션을 타므로,
+        // 거기서 얻은 프록시를 나중에 여기서 초기화하려 하면 LazyInitializationException이 날 수 있음)
+        IndustrySurvey survey = industrySurveyRepository.findById(request.surveyId())
+                .orElseThrow(() -> new SurveyException(SurveyErrorCode.SURVEY_NOT_FOUND));
+
+        // 응답 조회 (없으면 생성 - 동시 요청으로 중복 row가 생기지 않도록 안전하게 생성)
         IndustryResponse industryResponse = industryResponseRepository
                 .findByUserYearRoundIdAndIndustrySurveyIdAndIndustryDataId(
                         userYearRound.getId(),
                         request.surveyId(),
                         dataId
                 )
-                .orElseGet(() -> {
-                    assignment.incrementResponseCount();
-
-                    return IndustryResponse.builder()
-                                .userYearRound(userYearRound)
-                                .industrySurvey(industrySurveyRepository.getReferenceById(request.surveyId()))
-                                .industryData(industryDataRepository.getReferenceById(dataId))
-                                .build();
-                });
+                .orElseGet(() -> createIndustryResponseSafely(userYearRound, assignment, dataId, request.surveyId()));
 
         // 응답값 갱신
-        IndustrySurvey survey = industryResponse.getIndustrySurvey();
         if (survey.getSurveyType() == SurveyType.NUMBER) {
             industryResponse.updateNumberResponse(request.response());
         } else if (survey.getSurveyType() == SurveyType.TEXT) {
@@ -387,6 +408,26 @@ public class SurveyService {
             industryResponse.updateTextResponse(request.textResponse());
         }
         industryResponseRepository.save(industryResponse);
+    }
+
+    /*
+    IndustryResponse 생성 (동시 요청 대비) - createVisualResponseSafely와 동일한 전략
+    */
+    private IndustryResponse createIndustryResponseSafely(
+            UserYearRound userYearRound, IndustryDataAssignment assignment, Long dataId, Long surveyId
+    ) {
+        try {
+            IndustryResponse created = surveyResponseUpsertHelper.createIndustryResponse(userYearRound, surveyId, dataId);
+            // 이 요청이 실제로 새로 만든 경우에만 카운트 (경쟁에서 진 요청은 중복 카운트하지 않음)
+            assignment.incrementResponseCount();
+            return created;
+        } catch (DataIntegrityViolationException e) {
+            log.info("동시 요청으로 인한 IndustryResponse 중복 생성 시도 감지 (userYearRoundId={}, surveyId={}, dataId={}) - 재조회로 처리",
+                    userYearRound.getId(), surveyId, dataId);
+            return industryResponseRepository
+                    .findByUserYearRoundIdAndIndustrySurveyIdAndIndustryDataId(userYearRound.getId(), surveyId, dataId)
+                    .orElseThrow(() -> new SurveyException(SurveyErrorCode.NOT_FOUND_DATA_ASSIGNMENT));
+        }
     }
 
     /*


### PR DESCRIPTION
## PR 작성 전 체크 리스트 (PR 생성시 해당 항목은 삭제 후 올려주세요!)

## ✨ PR 제목 규칙
> `feat: (docs: / hotfix: / fix: ) 기능명 (#이슈번호)` 형식으로 작성  
> 예시: `feat: google OAuth 구현 (#14)`

`close #{이슈 번호}`을 사용하면 PR이 merge되면 해당 이슈가 자동으로 닫힙니다.

## #⃣ 연관된 이슈

> ex) #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (스크린샷 첨부)

설문 응답을 동시에 저장할 때 같은 문항에 응답 row가 중복 생성될 수 있는 race condition을 수정했습니다.
- `VisualResponse` / `IndustryResponse`에 `(userYearRound, survey, data)` 유니크 제약 추가
- 응답 생성을 `REQUIRES_NEW` 트랜잭션으로 분리해서, 동시 요청 중 하나가 유니크 제약에 걸리면(경쟁에서 짐) 예외를 안전하게 잡고 재조회해서 처리하도록 함
- 동시 요청 4개로 재현 테스트 → 성공 4/4, 항상 row 1개로 수렴하는 것 확인 (`admin/repro/runner/DuplicateResponseReproRunner`)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요