### PR TITLE
refactor: GZIP 압축, Layered JAR 전환, Selenium 버전 정리

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,17 @@
-FROM eclipse-temurin:17-jre-alpine
+# 1단계: jar를 레이어별로 추출
+# (의존성 레이어는 코드가 바뀌어도 그대로라, 아래 2단계에서 Docker 레이어 캐시가 재사용됨)
+FROM eclipse-temurin:17-jre-alpine AS builder
+WORKDIR /workspace
 ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT [ "java", "-jar",  "/app.jar" ]
+RUN java -Djarmode=tools -jar app.jar extract --layers --launcher --destination extracted
+
+# 2단계: 추출된 레이어를 의존성 -> 애플리케이션 코드 순으로 복사
+# 의존성이 안 바뀌면 여기까지는 캐시 히트되고, 마지막 application 레이어만 새로 빌드/전송됨
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY --from=builder /workspace/extracted/dependencies/ ./
+COPY --from=builder /workspace/extracted/spring-boot-loader/ ./
+COPY --from=builder /workspace/extracted/snapshot-dependencies/ ./
+COPY --from=builder /workspace/extracted/application/ ./
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,9 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// Selenium
-	implementation 'org.seleniumhq.selenium:selenium-java:4.24.0'
+	// 4.24.0으로 명시했지만 다른 의존성이 더 최신 버전을 끌어와 실제로는 4.31.0이 쓰이고 있었음.
+	// 실제 해석되는 버전과 일치시켜 혼선 방지.
+	implementation 'org.seleniumhq.selenium:selenium-java:4.31.0'
 
 	// WebDriverManager
 	implementation 'io.github.bonigarcia:webdrivermanager:5.9.2'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,11 @@ spring:
       cookie:
         max-age: 7200
 
+server:
+  compression:
+    enabled: true
+    mime-types: text/html,text/plain,application/json
+    min-response-size: 1024
 
 aws:
   s3:


### PR DESCRIPTION

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (스크린샷 첨부)

성능/배포 관련 개선 3건입니다.
- **GZIP 압축 추가**: `server.compression.enabled: true` (JSON/HTML/text, 1KB 이상만 압축)
- **Selenium 버전 정리**: 4.24.0으로 명시했지만 실제론 4.31.0이 해석되고 있어서 버전 명시를 실제와 일치시킴
- **Dockerfile → Layered JAR 전환**: Fat JAR 통째로 복사하던 방식에서 의존성/애플리케이션 코드 레이어를 분리해서 복사하도록 변경. 코드만 바뀌면 의존성 레이어는 캐시 재사용되어 빌드/푸시/풀 시간이 줄어듦 (재배포 소요 시간 단축)
로컬에서 `docker build --platform linux/amd64`로 이미지 빌드 및 컨테이너 기동(JarLauncher → HdiApplication 정상 시작)까지 확인했습니다.

